### PR TITLE
Make the xell-1f.bin location more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ for some.
 * Allows more homebrew be able to be launched without erroring back to
   dashboard.
 * Fixes the ring of light / controller syncing bug after using BadUpdate.
-* Allows launching `xell-1f.bin` from the payload folder.
+* Allows launching `xell-1f.bin` from the `BadUpdatePayload` folder
 * Patches USB controller authentication check (a-la "UsbdSecPatch") to let
   certain compatible controllers and adapters work. That's for you, Mario.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ for some.
 * Allows more homebrew be able to be launched without erroring back to
   dashboard.
 * Fixes the ring of light / controller syncing bug after using BadUpdate.
-* Allows launching `xell-1f.bin` from the `BadUpdatePayload` folder
+* Allows launching `xell-1f.bin` from the `BadUpdatePayload` folder.
 * Patches USB controller authentication check (a-la "UsbdSecPatch") to let
   certain compatible controllers and adapters work. That's for you, Mario.
 


### PR DESCRIPTION
whole yesterday I was convinced I'm supposed to make a folder named "payloads" on the USB root, but after looking at the release notes and the source code it was not the case. feel free to laugh